### PR TITLE
✨ Auto-invoke nested objects

### DIFF
--- a/src/Attribute/ObjectType/LegacyThemeDefinitionTrait.php
+++ b/src/Attribute/ObjectType/LegacyThemeDefinitionTrait.php
@@ -7,6 +7,7 @@ namespace Pinto\Attribute\ObjectType;
 use Pinto\Exception\PintoBuildDefinitionMismatch;
 use Pinto\Exception\PintoThemeDefinition;
 use Pinto\List\ObjectListInterface;
+use Pinto\ObjectType\LateBindObjectContext;
 use Pinto\ObjectType\ObjectTypeInterface;
 use Pinto\ThemeDefinition\HookThemeDefinition;
 
@@ -38,7 +39,7 @@ trait LegacyThemeDefinitionTrait
         ];
     }
 
-    public static function lateBindObjectToBuild(mixed $build, mixed $definition, object $object): void
+    public static function lateBindObjectToBuild(mixed $build, mixed $definition, object $object, LateBindObjectContext $context): void
     {
     }
 

--- a/src/CanonicalProduct/CanonicalFactoryTrait.php
+++ b/src/CanonicalProduct/CanonicalFactoryTrait.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Pinto\CanonicalProduct;
 
-use Pinto\Attribute\Build;
 use Pinto\PintoMapping;
 
 trait CanonicalFactoryTrait
 {
-    #[Build]
     final public static function create(mixed ...$args): self
     {
         $className = self::pintoMappingStatic()->getCanonicalObjectClassName(self::class);

--- a/src/Object/ObjectTrait.php
+++ b/src/Object/ObjectTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pinto\Object;
 
 use Pinto\Exception\PintoBuildDefinitionMismatch;
+use Pinto\ObjectType\LateBindObjectContext;
 use Pinto\PintoMapping;
 
 /**
@@ -49,7 +50,7 @@ trait ObjectTrait
         // for all enums (theme objects) under its control.
         $built = (static::$pintoEnum[static::class]->build($wrapper, $this))($build);
 
-        $objectType::lateBindObjectToBuild($built, $definition, $this);
+        $objectType::lateBindObjectToBuild($built, $definition, $this, LateBindObjectContext::create($this->pintoMapping()));
         $objectType::validateBuild($built, $definition, static::class);
 
         return $built;

--- a/src/ObjectType/LateBindObjectContext.php
+++ b/src/ObjectType/LateBindObjectContext.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\ObjectType;
+
+use Pinto\Exception\PintoMissingObjectMapping;
+use Pinto\PintoMapping;
+
+/**
+ * Discovers ObjectTypeInterface attributes on a class, on a class or its methods.
+ *
+ * @internal
+ */
+final class LateBindObjectContext
+{
+    private function __construct(
+        private PintoMapping $pintoMapping,
+    ) {
+    }
+
+    /**
+     * @internal
+     */
+    public static function create(PintoMapping $pintoMapping): static
+    {
+        return new static($pintoMapping);
+    }
+
+    /**
+     * @param class-string $objectClassName
+     */
+    public function getBuildInvoker(string $objectClassName): ?string
+    {
+        try {
+            return $this->pintoMapping->getBuildInvoker($objectClassName);
+        } catch (PintoMissingObjectMapping) {
+            return null;
+        }
+    }
+}

--- a/src/ObjectType/ObjectTypeInterface.php
+++ b/src/ObjectType/ObjectTypeInterface.php
@@ -13,7 +13,7 @@ interface ObjectTypeInterface
 {
     public static function createBuild(ObjectListInterface $case, mixed $definition, string $objectClassName): mixed;
 
-    public static function lateBindObjectToBuild(mixed $build, mixed $definition, object $object): void;
+    public static function lateBindObjectToBuild(mixed $build, mixed $definition, object $object, LateBindObjectContext $context): void;
 
     /**
      * @phpstan-param class-string $objectClassName

--- a/tests/PintoAutoInvokeNestedTest.php
+++ b/tests/PintoAutoInvokeNestedTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Pinto\Slots\Build;
+use Pinto\tests\fixtures\Objects\AutoInvokeNested\PintoObjectAutoInvokeContainer;
+
+final class PintoAutoInvokeNestedTest extends TestCase
+{
+    /**
+     * Test auto-invoking builds of nested objects.
+     *
+     * Where nesting fixtures are arranged as:
+     *
+     * Container
+     * ├─ Child1
+     * └─ Child2
+     *    └─ Child3
+     *
+     * @see PintoObjectAutoInvokeContainer
+     * @see Pinto\tests\fixtures\Objects\AutoInvokeNested\PintoObjectAutoInvokeChild1
+     * @see Pinto\tests\fixtures\Objects\AutoInvokeNested\PintoObjectAutoInvokeChild2
+     * @see Pinto\tests\fixtures\Objects\AutoInvokeNested\PintoObjectAutoInvokeChild3
+     */
+    public function testNested(): void
+    {
+        $object = new PintoObjectAutoInvokeContainer(foo: 'Text in Container');
+        $build = $object();
+
+        // PintoObjectAutoInvokeContainer build and slot values.
+        static::assertInstanceOf(Build::class, $build);
+        static::assertEquals('Text in Container', $build->pintoGet('text'));
+
+        // PintoObjectAutoInvokeChild1 build and slot values.
+        static::assertInstanceOf(Build::class, $build->pintoGet('child_1'));
+        static::assertEquals('Text in Child1', $build->pintoGet('child_1')->pintoGet('child1_text'));
+        static::assertInstanceOf(Build::class, $build->pintoGet('child_2'));
+
+        // PintoObjectAutoInvokeChild2 build and slot values.
+        static::assertEquals('Text in Child2', $build->pintoGet('child_2')->pintoGet('child2_text'));
+        static::assertInstanceOf(Build::class, $build->pintoGet('child_2')->pintoGet('child2_child'));
+
+        // PintoObjectAutoInvokeChild3 build and slot values.
+        static::assertEquals('Text in Child3', $build->pintoGet('child_2')->pintoGet('child2_child')->pintoGet('child3_text'));
+    }
+}

--- a/tests/PintoAutoInvokeNestedTest.php
+++ b/tests/PintoAutoInvokeNestedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use Pinto\Slots\Build;
 use Pinto\tests\fixtures\Objects\AutoInvokeNested\PintoObjectAutoInvokeContainer;
+use Pinto\tests\fixtures\Objects\Faulty\PintoObjectAutoInvokeNotKnownObject;
 
 final class PintoAutoInvokeNestedTest extends TestCase
 {
@@ -43,5 +44,14 @@ final class PintoAutoInvokeNestedTest extends TestCase
 
         // PintoObjectAutoInvokeChild3 build and slot values.
         static::assertEquals('Text in Child3', $build->pintoGet('child_2')->pintoGet('child2_child')->pintoGet('child3_text'));
+    }
+
+    public function testUnknownChildObject(): void
+    {
+        $object = new PintoObjectAutoInvokeNotKnownObject();
+        $build = $object();
+        // The slot value is the original instance.
+        static::assertInstanceOf(Build::class, $build);
+        static::assertInstanceOf(stdClass::class, $build->pintoGet('child'));
     }
 }

--- a/tests/fixtures/Lists/AutoInvokeNested/PintoListAutoInvokeNested.php
+++ b/tests/fixtures/Lists/AutoInvokeNested/PintoListAutoInvokeNested.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Lists\AutoInvokeNested;
+
+use Pinto\Attribute\Definition;
+use Pinto\Attribute\ObjectType;
+use Pinto\List\ObjectListInterface;
+use Pinto\List\ObjectListTrait;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductChild;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductRoot;
+
+#[ObjectType\Slots]
+enum PintoListAutoInvokeNested implements ObjectListInterface
+{
+    use ObjectListTrait;
+
+    #[Definition(PintoObjectCanonicalProductRoot::class)]
+    case Containing;
+
+    #[Definition(PintoObjectCanonicalProductChild::class)]
+    case Child1;
+
+    #[Definition(PintoObjectCanonicalProductChild::class)]
+    case Child2;
+
+    case Child3;
+
+    public function templateDirectory(): string
+    {
+        throw new \LogicException('Object level logic not tested.');
+    }
+
+    public function cssDirectory(): string
+    {
+        throw new \LogicException('Object level logic not tested.');
+    }
+
+    public function jsDirectory(): string
+    {
+        throw new \LogicException('Object level logic not tested.');
+    }
+}

--- a/tests/fixtures/Lists/PintoFaultyList.php
+++ b/tests/fixtures/Lists/PintoFaultyList.php
@@ -25,6 +25,9 @@ enum PintoFaultyList implements ObjectListInterface
     #[Definition(fixtures\Objects\Faulty\PintoObjectSlotsBindPromotedPublicWithDefinedSlots::class)]
     case PintoObjectSlotsBindPromotedPublicWithDefinedSlots;
 
+    #[Definition(fixtures\Objects\Faulty\PintoObjectAutoInvokeNotKnownObject::class)]
+    case PintoObjectAutoInvokeNotKnownObject;
+
     public function templateDirectory(): string
     {
         return 'tests/fixtures/resources';

--- a/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeChild1.php
+++ b/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeChild1.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\AutoInvokeNested;
+
+use Pinto\Attribute\ObjectType;
+use Pinto\Object\ObjectTrait;
+use Pinto\PintoMapping;
+use Pinto\Slots;
+use Pinto\tests\fixtures\Lists\AutoInvokeNested\PintoListAutoInvokeNested;
+
+/**
+ * PintoListAutoInvokeNested test object.
+ */
+#[ObjectType\Slots(slots: [
+    'child1_text',
+])]
+class PintoObjectAutoInvokeChild1
+{
+    use ObjectTrait;
+
+    final public function __construct()
+    {
+    }
+
+    public function __invoke(): mixed
+    {
+        return $this->pintoBuild(function (Slots\Build $build): Slots\Build {
+            return $build
+              ->set('child1_text', 'Text in Child1');
+        });
+    }
+
+    private static function pintoMappingStatic(): PintoMapping
+    {
+        return PintoObjectAutoInvokeContainer::pintoMappingStatic();
+    }
+
+    private function pintoMapping(): PintoMapping
+    {
+        return self::pintoMappingStatic();
+    }
+}

--- a/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeChild2.php
+++ b/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeChild2.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\AutoInvokeNested;
+
+use Pinto\Attribute\ObjectType;
+use Pinto\Object\ObjectTrait;
+use Pinto\PintoMapping;
+use Pinto\Slots;
+use Pinto\tests\fixtures\Lists\AutoInvokeNested\PintoListAutoInvokeNested;
+
+/**
+ * PintoListAutoInvokeNested test object.
+ */
+#[ObjectType\Slots(slots: [
+    'child2_text',
+    'child2_child',
+])]
+class PintoObjectAutoInvokeChild2
+{
+    use ObjectTrait;
+
+    final public function __construct()
+    {
+    }
+
+    public function __invoke(): mixed
+    {
+        return $this->pintoBuild(function (Slots\Build $build): Slots\Build {
+            return $build
+              ->set('child2_text', 'Text in Child2')
+              ->set('child2_child', new PintoObjectAutoInvokeChild3());
+        });
+    }
+
+    private static function pintoMappingStatic(): PintoMapping
+    {
+        return PintoObjectAutoInvokeContainer::pintoMappingStatic();
+    }
+
+    private function pintoMapping(): PintoMapping
+    {
+        return self::pintoMappingStatic();
+    }
+}

--- a/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeChild3.php
+++ b/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeChild3.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\AutoInvokeNested;
+
+use Pinto\Attribute\ObjectType;
+use Pinto\Object\ObjectTrait;
+use Pinto\PintoMapping;
+use Pinto\Slots;
+use Pinto\tests\fixtures\Lists\AutoInvokeNested\PintoListAutoInvokeNested;
+
+/**
+ * PintoListAutoInvokeNested test object.
+ */
+#[ObjectType\Slots(slots: [
+    'child3_text',
+])]
+class PintoObjectAutoInvokeChild3
+{
+    use ObjectTrait;
+
+    final public function __construct()
+    {
+    }
+
+    public function __invoke(): mixed
+    {
+        return $this->pintoBuild(function (Slots\Build $build): Slots\Build {
+            return $build
+              ->set('child3_text', 'Text in Child3');
+        });
+    }
+
+    private static function pintoMappingStatic(): PintoMapping
+    {
+        return PintoObjectAutoInvokeContainer::pintoMappingStatic();
+    }
+
+    private function pintoMapping(): PintoMapping
+    {
+        return self::pintoMappingStatic();
+    }
+}

--- a/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeContainer.php
+++ b/tests/fixtures/Objects/AutoInvokeNested/PintoObjectAutoInvokeContainer.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\AutoInvokeNested;
+
+use Pinto\Attribute\ObjectType;
+use Pinto\DefinitionDiscovery;
+use Pinto\Object\ObjectTrait;
+use Pinto\PintoMapping;
+use Pinto\Slots;
+use Pinto\tests\fixtures\Lists\AutoInvokeNested\PintoListAutoInvokeNested;
+
+/**
+ * PintoListAutoInvokeNested test object.
+ */
+#[ObjectType\Slots(slots: [
+    'text',
+    'child_1',
+    'child_2',
+])]
+class PintoObjectAutoInvokeContainer
+{
+    use ObjectTrait;
+
+    private PintoObjectAutoInvokeChild1 $child1;
+
+    final public function __construct(
+        private string $foo,
+    ) {
+        $this->child1 = new PintoObjectAutoInvokeChild1();
+    }
+
+    public function __invoke(): mixed
+    {
+        return $this->pintoBuild(function (Slots\Build $build): Slots\Build {
+            return $build
+              ->set('text', $this->foo)
+              ->set('child_1', $this->child1)
+              ->set('child_2', new PintoObjectAutoInvokeChild2())
+            ;
+        });
+    }
+
+    public static function pintoMappingStatic(): PintoMapping
+    {
+        $definitionDiscovery = new DefinitionDiscovery();
+        $definitionDiscovery[PintoObjectAutoInvokeContainer::class] = PintoListAutoInvokeNested::Containing;
+        $definitionDiscovery[PintoObjectAutoInvokeChild1::class] = PintoListAutoInvokeNested::Child1;
+        $definitionDiscovery[PintoObjectAutoInvokeChild2::class] = PintoListAutoInvokeNested::Child2;
+        $definitionDiscovery[PintoObjectAutoInvokeChild3::class] = PintoListAutoInvokeNested::Child3;
+
+        return new PintoMapping(
+            enumClasses: [
+                // Not tested.
+            ],
+            enums: [
+                static::class => [PintoListAutoInvokeNested::class, PintoListAutoInvokeNested::Containing->name],
+                PintoObjectAutoInvokeChild1::class => [PintoListAutoInvokeNested::class, PintoListAutoInvokeNested::Child1->name],
+                PintoObjectAutoInvokeChild2::class => [PintoListAutoInvokeNested::class, PintoListAutoInvokeNested::Child2->name],
+                PintoObjectAutoInvokeChild3::class => [PintoListAutoInvokeNested::class, PintoListAutoInvokeNested::Child3->name],
+            ],
+            definitions: [
+                static::class => new Slots\Definition(new Slots\SlotList([
+                    new Slots\Slot(name: 'text'),
+                    new Slots\Slot(name: 'child_1'),
+                    new Slots\Slot(name: 'child_2'),
+                ])),
+                PintoObjectAutoInvokeChild1::class => new Slots\Definition(new Slots\SlotList([
+                    new Slots\Slot(name: 'child1_text'),
+                ])),
+                PintoObjectAutoInvokeChild2::class => new Slots\Definition(new Slots\SlotList([
+                    new Slots\Slot(name: 'child2_text'),
+                    new Slots\Slot(name: 'child2_child'),
+                ])),
+                PintoObjectAutoInvokeChild3::class => new Slots\Definition(new Slots\SlotList([
+                    new Slots\Slot(name: 'child3_text'),
+                ])),
+            ],
+            buildInvokers: [
+                static::class => '__invoke',
+                PintoObjectAutoInvokeChild1::class => '__invoke',
+                PintoObjectAutoInvokeChild2::class => '__invoke',
+                PintoObjectAutoInvokeChild3::class => '__invoke',
+            ],
+            types: [
+                static::class => ObjectType\Slots::class,
+                PintoObjectAutoInvokeChild1::class => ObjectType\Slots::class,
+                PintoObjectAutoInvokeChild2::class => ObjectType\Slots::class,
+                PintoObjectAutoInvokeChild3::class => ObjectType\Slots::class,
+            ],
+            lsbFactoryCanonicalObjectClasses: [],
+        );
+    }
+
+    private function pintoMapping(): PintoMapping
+    {
+        return self::pintoMappingStatic();
+    }
+}

--- a/tests/fixtures/Objects/Faulty/PintoObjectAutoInvokeNotKnownObject.php
+++ b/tests/fixtures/Objects/Faulty/PintoObjectAutoInvokeNotKnownObject.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\Faulty;
+
+use Pinto\Attribute\ObjectType;
+use Pinto\DefinitionDiscovery;
+use Pinto\Object\ObjectTrait;
+use Pinto\PintoMapping;
+use Pinto\Slots;
+use Pinto\tests\fixtures\Lists\PintoFaultyList;
+
+/**
+ * Where a slot is filled by an object which is not known.
+ *
+ * Coverage for \Pinto\ObjectType\LateBindObjectContext::getBuildInvoker null return.
+ */
+#[ObjectType\Slots(slots: [
+    'child',
+])]
+class PintoObjectAutoInvokeNotKnownObject
+{
+    use ObjectTrait;
+
+    final public function __construct()
+    {
+    }
+
+    public function __invoke(): mixed
+    {
+        return $this->pintoBuild(function (Slots\Build $build): Slots\Build {
+            return $build
+              ->set('child', new \stdClass());
+        });
+    }
+
+    public static function pintoMappingStatic(): PintoMapping
+    {
+        $definitionDiscovery = new DefinitionDiscovery();
+        $definitionDiscovery[static::class] = PintoFaultyList::PintoObjectAutoInvokeNotKnownObject;
+
+        return new PintoMapping(
+            enumClasses: [
+                // Not tested.
+            ],
+            enums: [
+                static::class => [PintoFaultyList::class, PintoFaultyList::PintoObjectAutoInvokeNotKnownObject->name],
+            ],
+            definitions: [
+                static::class => new Slots\Definition(new Slots\SlotList([
+                    new Slots\Slot(name: 'child'),
+                ])),
+            ],
+            buildInvokers: [
+                static::class => '__invoke',
+            ],
+            types: [
+                static::class => ObjectType\Slots::class,
+            ],
+            lsbFactoryCanonicalObjectClasses: [],
+        );
+    }
+
+    private function pintoMapping(): PintoMapping
+    {
+        return self::pintoMappingStatic();
+    }
+}


### PR DESCRIPTION
Autoinvoking nested objects / Autoinvoke slot object values

When a slot value is set to a known theme object, automatically call its invoke method and replace the value of the slot with that value.

This feature is currently only implemneted by the **Slots** object type.

todo: Show nested render array in docs
