### PR TITLE
✨ Rename method so `final create` doesnt use up valuable namespace

### DIFF
--- a/src/CanonicalProduct/CanonicalFactoryTrait.php
+++ b/src/CanonicalProduct/CanonicalFactoryTrait.php
@@ -8,7 +8,7 @@ use Pinto\PintoMapping;
 
 trait CanonicalFactoryTrait
 {
-    final public static function create(mixed ...$args): self
+    final public static function factoryCreate(mixed ...$args): self
     {
         $className = self::pintoMappingStatic()->getCanonicalObjectClassName(self::class);
         if (null === $className) {

--- a/tests/PintoCanonicalProductTest.php
+++ b/tests/PintoCanonicalProductTest.php
@@ -35,7 +35,7 @@ final class PintoCanonicalProductTest extends TestCase
      */
     public function testCreateUsesTraitWithoutAttribute(): void
     {
-        $object = PintoObjectCanonicalProductWithoutAttrChild::create('foo bar');
+        $object = PintoObjectCanonicalProductWithoutAttrChild::factoryCreate('foo bar');
         static::assertInstanceOf(PintoObjectCanonicalProductWithoutAttrChild::class, $object);
     }
 
@@ -50,7 +50,7 @@ final class PintoCanonicalProductTest extends TestCase
     {
         static::expectException(PintoMultipleCanonicalProduct::class);
         static::expectExceptionMessage('Multiple objects are contested to override object `' . PintoObjectCanonicalProductContestedRoot::class . '` where only one is permitted: ' . PintoObjectCanonicalProductContestedChild1::class . ', ' . PintoObjectCanonicalProductContestedChild2::class);
-        PintoObjectCanonicalProductContestedRoot::create();
+        PintoObjectCanonicalProductContestedRoot::factoryCreate();
     }
 
     /**
@@ -69,10 +69,10 @@ final class PintoCanonicalProductTest extends TestCase
 
     public function testCanonicalProductAttributeOnList(): void
     {
-        $object = PintoObjectCanonicalProductOnListRoot1::create();
+        $object = PintoObjectCanonicalProductOnListRoot1::factoryCreate();
         static::assertInstanceOf(PintoObjectCanonicalProductOnListChild1::class, $object);
 
-        $object = PintoObjectCanonicalProductOnListRoot2::create();
+        $object = PintoObjectCanonicalProductOnListRoot2::factoryCreate();
         static::assertInstanceOf(PintoObjectCanonicalProductOnListChild2::class, $object);
     }
 }

--- a/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductRoot.php
+++ b/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductRoot.php
@@ -23,7 +23,7 @@ class PintoObjectCanonicalProductRoot
     use ObjectTrait;
 
     use CanonicalFactoryTrait {
-        CanonicalFactoryTrait::create as customCreate;
+        CanonicalFactoryTrait::factoryCreate as customCreate;
     }
 
     final public function __construct(


### PR DESCRIPTION
At least make it possible to rename the method in trait imports.