### PR TITLE
✨ Support multiple CanonicalProducts in a hierarchy

### DIFF
--- a/tests/PintoCanonicalProductTest.php
+++ b/tests/PintoCanonicalProductTest.php
@@ -8,10 +8,16 @@ use Pinto\CanonicalProduct\Exception\PintoMultipleCanonicalProduct;
 use Pinto\DefinitionDiscovery;
 use Pinto\Slots\Build;
 use Pinto\tests\fixtures\Lists\CanonicalProduct\PintoListCanonicalProductContested;
+use Pinto\tests\fixtures\Lists\CanonicalProduct\PintoListCanonicalProductHierarchy;
 use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductChild;
 use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductContestedChild1;
 use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductContestedChild2;
 use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductContestedRoot;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyChild;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyChild2;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyGrandParent;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyGreatGrandParent;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyParent;
 use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductOnListChild1;
 use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductOnListChild2;
 use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductOnListRoot1;
@@ -65,6 +71,67 @@ final class PintoCanonicalProductTest extends TestCase
         $definitionDiscovery[PintoObjectCanonicalProductContestedChild2::class] = PintoListCanonicalProductContested::Child2;
         $definitionDiscovery[PintoObjectCanonicalProductContestedRoot::class] = PintoListCanonicalProductContested::Root;
         CanonicalProduct::discoverCanonicalProductObjectClasses($definitionDiscovery);
+    }
+
+    /**
+     * @covers \Pinto\CanonicalProduct\Attribute\CanonicalProduct::discoverCanonicalProductObjectClasses
+     */
+    public function testDiscoverCanonicalProductHierarchy(): void
+    {
+        $definitionDiscovery = new DefinitionDiscovery();
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyGrandParent::class] = PintoListCanonicalProductHierarchy::GrandParent;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyParent::class] = PintoListCanonicalProductHierarchy::Parent;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyChild::class] = PintoListCanonicalProductHierarchy::Child;
+        self::assertEquals([
+            // Parent is eliminated.
+            PintoObjectCanonicalProductHierarchyGrandParent::class => PintoObjectCanonicalProductHierarchyChild::class,
+        ], CanonicalProduct::discoverCanonicalProductObjectClasses($definitionDiscovery));
+    }
+
+    /**
+     * Where two children extend a parent extend a root.
+     *
+     * The parent is correctly eliminated, but children don't extend each-other.
+     *
+     * Where:
+     * R1
+     * └── P1
+     *     ├── C1
+     *     └── C2
+     *
+     * @covers \Pinto\CanonicalProduct\Attribute\CanonicalProduct::discoverCanonicalProductObjectClasses
+     */
+    public function testDiscoverCanonicalProductHierarchyContested(): void
+    {
+        $definitionDiscovery = new DefinitionDiscovery();
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyGrandParent::class] = PintoListCanonicalProductHierarchy::GrandParent;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyParent::class] = PintoListCanonicalProductHierarchy::Parent;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyChild::class] = PintoListCanonicalProductHierarchy::Child;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyChild2::class] = PintoListCanonicalProductHierarchy::Child2;
+
+        static::expectException(PintoMultipleCanonicalProduct::class);
+        static::expectExceptionMessage('Multiple objects are contested to override object `' . PintoObjectCanonicalProductHierarchyGrandParent::class . '` where only one is permitted: ' . PintoObjectCanonicalProductHierarchyChild::class . ', ' . PintoObjectCanonicalProductHierarchyChild2::class);
+        CanonicalProduct::discoverCanonicalProductObjectClasses($definitionDiscovery);
+    }
+
+    /**
+     * Ensure object hierarchy stops on the first object without #[CanonicalProduct].
+     *
+     * Ensure hierarchy stops at PintoObjectCanonicalProductHierarchyGrandParent instead of going up the chain to PintoObjectCanonicalProductHierarchyGreatGrandParent.
+     *
+     * @covers \Pinto\CanonicalProduct\Attribute\CanonicalProduct::discoverCanonicalProductObjectClasses
+     */
+    public function testDiscoverCanonicalProductHierarchyStopsAtFirstNonCanonical(): void
+    {
+        $definitionDiscovery = new DefinitionDiscovery();
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyGreatGrandParent::class] = PintoListCanonicalProductHierarchy::GreatGrandParent;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyGrandParent::class] = PintoListCanonicalProductHierarchy::GrandParent;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyParent::class] = PintoListCanonicalProductHierarchy::Parent;
+        $definitionDiscovery[PintoObjectCanonicalProductHierarchyChild::class] = PintoListCanonicalProductHierarchy::Child;
+        self::assertEquals([
+            // See GreatGrandParent isn't resolved as root since the `hasAttribute` check is in place.
+            PintoObjectCanonicalProductHierarchyGrandParent::class => PintoObjectCanonicalProductHierarchyChild::class,
+        ], CanonicalProduct::discoverCanonicalProductObjectClasses($definitionDiscovery));
     }
 
     public function testCanonicalProductAttributeOnList(): void

--- a/tests/fixtures/Lists/CanonicalProduct/PintoListCanonicalProductHierarchy.php
+++ b/tests/fixtures/Lists/CanonicalProduct/PintoListCanonicalProductHierarchy.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Lists\CanonicalProduct;
+
+use Pinto\Attribute\Definition;
+use Pinto\Attribute\ObjectType;
+use Pinto\List\ObjectListInterface;
+use Pinto\List\ObjectListTrait;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyChild;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyChild2;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyGrandParent;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyGreatGrandParent;
+use Pinto\tests\fixtures\Objects\CanonicalProduct\PintoObjectCanonicalProductHierarchyParent;
+
+#[ObjectType\Slots]
+enum PintoListCanonicalProductHierarchy implements ObjectListInterface
+{
+    use ObjectListTrait;
+
+    #[Definition(PintoObjectCanonicalProductHierarchyGreatGrandParent::class)]
+    case GreatGrandParent;
+
+    #[Definition(PintoObjectCanonicalProductHierarchyGrandParent::class)]
+    case GrandParent;
+
+    #[Definition(PintoObjectCanonicalProductHierarchyParent::class)]
+    case Parent;
+
+    #[Definition(PintoObjectCanonicalProductHierarchyChild::class)]
+    case Child;
+
+    #[Definition(PintoObjectCanonicalProductHierarchyChild2::class)]
+    case Child2;
+
+    public function templateDirectory(): string
+    {
+        return 'tests/fixtures/resources';
+    }
+
+    public function cssDirectory(): string
+    {
+        return 'tests/fixtures/resources';
+    }
+
+    public function jsDirectory(): string
+    {
+        return 'tests/fixtures/resources';
+    }
+}

--- a/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyChild.php
+++ b/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyChild.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\CanonicalProduct;
+
+use Pinto\CanonicalProduct\Attribute\CanonicalProduct;
+
+/**
+ * CanonicalProduct test object.
+ */
+#[CanonicalProduct]
+final class PintoObjectCanonicalProductHierarchyChild extends PintoObjectCanonicalProductHierarchyParent
+{
+}

--- a/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyChild2.php
+++ b/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyChild2.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\CanonicalProduct;
+
+use Pinto\CanonicalProduct\Attribute\CanonicalProduct;
+
+/**
+ * CanonicalProduct test object.
+ */
+#[CanonicalProduct]
+final class PintoObjectCanonicalProductHierarchyChild2 extends PintoObjectCanonicalProductHierarchyParent
+{
+}

--- a/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyGrandParent.php
+++ b/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyGrandParent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\CanonicalProduct;
+
+use Pinto\Attribute\ObjectType;
+use Pinto\CanonicalProduct\Attribute\CanonicalProduct;
+
+/**
+ * CanonicalProduct test object.
+ */
+#[ObjectType\Slots]
+class PintoObjectCanonicalProductHierarchyGrandParent extends PintoObjectCanonicalProductHierarchyGreatGrandParent
+{
+}

--- a/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyGreatGrandParent.php
+++ b/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyGreatGrandParent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\CanonicalProduct;
+
+use Pinto\Attribute\ObjectType;
+use Pinto\CanonicalProduct\Attribute\CanonicalProduct;
+use Pinto\CanonicalProduct\CanonicalFactoryTrait;
+use Pinto\Object\ObjectTrait;
+use Pinto\PintoMapping;
+
+/**
+ * CanonicalProduct test object.
+ */
+#[ObjectType\Slots]
+class PintoObjectCanonicalProductHierarchyGreatGrandParent
+{
+    use ObjectTrait;
+
+    use CanonicalFactoryTrait;
+
+    final public function __construct()
+    {
+    }
+
+    public function __invoke(): mixed
+    {
+        throw new \LogicException('Object level logic not tested.');
+    }
+
+    private static function pintoMappingStatic(): PintoMapping
+    {
+        throw new \LogicException('Not tested.');
+    }
+
+    private function pintoMapping(): PintoMapping
+    {
+        return self::pintoMappingStatic();
+    }
+}

--- a/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyParent.php
+++ b/tests/fixtures/Objects/CanonicalProduct/PintoObjectCanonicalProductHierarchyParent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pinto\tests\fixtures\Objects\CanonicalProduct;
+
+use Pinto\CanonicalProduct\Attribute\CanonicalProduct;
+
+/**
+ * CanonicalProduct test object.
+ */
+#[CanonicalProduct]
+class PintoObjectCanonicalProductHierarchyParent extends PintoObjectCanonicalProductHierarchyGrandParent
+{
+}


### PR DESCRIPTION
If an object extends another CanonicalProduct, Pinto will searching til the first non CanonicalProduct object. Partially addresses #36